### PR TITLE
fix GCC flag list being overwritten by the clang list

### DIFF
--- a/cmake/target_config.cmake
+++ b/cmake/target_config.cmake
@@ -35,10 +35,10 @@ function(apply_compilation_config_to_target target_name)
             add_compile_options(-moutline-atomics)
         endif()
         set(MAG_CLANG_COMPILE_FLAGS ${MAG_CLANG_COMPILE_FLAGS} -march=armv8-a -moutline-atomics) # See beginning for file for info of -moutline-atomics
-        set(MAG_GCC_COMPILE_FLAGS ${MAG_CLANG_COMPILE_FLAGS} -march=armv8-a -moutline-atomics)
+        set(MAG_GCC_COMPILE_FLAGS ${MAG_GCC_COMPILE_FLAGS} -march=armv8-a -moutline-atomics)
     elseif (${IS_AMD64})
         set(MAG_CLANG_COMPILE_FLAGS ${MAG_CLANG_COMPILE_FLAGS} -msse -msse2)
-        set(MAG_GCC_COMPILE_FLAGS ${MAG_CLANG_COMPILE_FLAGS} -msse -msse2)
+        set(MAG_GCC_COMPILE_FLAGS ${MAG_GCC_COMPILE_FLAGS} -msse -msse2)
     endif()
 
     if(WIN32) # Windows (MSVC) specific config


### PR DESCRIPTION
`cmake/target_config.cmake:38` and `:41` assign `MAG_GCC_COMPILE_FLAGS` from `${MAG_CLANG_COMPILE_FLAGS}`, so every GCC-only flag from the list at line 26 is dropped before it reaches the compiler, on both the ARM64 and AMD64 branches. The two lists differ by exactly one entry, `-Wno-error=format-truncation`, which is why #48 hit `-Werror=format-truncation=` rather than a warning. You'd already decided that shouldn't fail the build; it just never applied. Unpatched `C_FLAGS` on x86-64 has `-Wno-error=parentheses` and `-Wno-error=overflow` but no format-truncation entry; with this it's there.

Reproduced the original at `7ccddd5` with GCC 14.3 and `-DCMAKE_BUILD_TYPE=Debug`: four errors at `mag_op_stubs.c` 1160, 1235, 1262 and 1282, matching the issue's numbers (375 / 219 / mag_def.h:539:62). It's `-O0` only, since at `-O2` the value range for the shape buffer collapses and GCC stops warning, which is probably why it looked fine to you. Same tree with this patch gives four warnings and completes.

The ARM64 branch also appended `-march=armv8-a -moutline-atomics` to a list that had just received them, so GCC got them twice. Now once.

Tests are 62/62 before and after, as expected for a diagnostic-only flag.

Worth knowing separately: the site #48 reports is already gone from master, but by accident. `mag_contract` became `mag_set_error_impl` (mag_def.c:377), where the format string is a runtime `const char*` behind a function boundary in its own TU, so GCC can't see the call sites any more. The warning went away because the compiler was blinded, not because the buffer grew. `mag_error_t::message` is still `char[256]` (magnetron.h:136) across 551 `mag_set_error` call sites, some formatting two or three shape strings into it, and two rank-16 shapes with 6-digit dims run about 128 characters each. Silent truncation is still reachable. I left that alone since `message` sits in a public struct passed by value, so resizing it is an ABI break and your call, not mine.
